### PR TITLE
(#8) use correct name when denying ruby agents

### DIFF
--- a/mcorpc/golang/provider.go
+++ b/mcorpc/golang/provider.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/choria-io/go-choria/build"
 	"github.com/choria-io/go-choria/choria"
+	"github.com/choria-io/go-choria/server"
+	"github.com/choria-io/go-choria/server/agents"
 	"github.com/choria-io/mcorpc-agent-provider/mcorpc/golang/choriautil"
 	"github.com/choria-io/mcorpc-agent-provider/mcorpc/golang/discovery"
 	"github.com/choria-io/mcorpc-agent-provider/mcorpc/golang/provision"
 	"github.com/choria-io/mcorpc-agent-provider/mcorpc/golang/rpcutil"
-	"github.com/choria-io/go-choria/server"
-	"github.com/choria-io/go-choria/server/agents"
 	"github.com/sirupsen/logrus"
 )
 

--- a/mcorpc/ruby/provider.go
+++ b/mcorpc/ruby/provider.go
@@ -7,8 +7,8 @@ import (
 	"github.com/choria-io/go-choria/build"
 	"github.com/choria-io/go-choria/choria"
 	"github.com/choria-io/go-choria/config"
-	"github.com/choria-io/mcorpc-agent-provider/mcorpc/ddl/agent"
 	"github.com/choria-io/go-choria/server"
+	"github.com/choria-io/mcorpc-agent-provider/mcorpc/ddl/agent"
 	"github.com/sirupsen/logrus"
 )
 

--- a/mcorpc/ruby/util.go
+++ b/mcorpc/ruby/util.go
@@ -28,8 +28,9 @@ func (p *Provider) eachAgent(libdirs []string, cb func(ddl *agentddl.DDL)) {
 				return nil
 			}
 
-			extension := filepath.Ext(info.Name())
-			name := path[0 : len(path)-len(extension)]
+			fname := info.Name()
+			extension := filepath.Ext(fname)
+			name := fname[0 : len(fname)-len(extension)]
 
 			if extension != ".json" {
 				return nil


### PR DESCRIPTION
The fq path was used to determin the agent name, should be the short
name instead