### PR TITLE
(#13, #14, #15) rework discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 This is an Agent Provider for the [Choria Server](https://github.com/choria-io/go-choria) that provides compatability with The Marionette Collective (mcollective) Simple RPC system.
 
-Features:
+Agent Features:
 
  * Agent DDLs represented in memory and loaded from JSON files
- * Agents, Actions and Agent Metadata that maps to the same terminology and behaviour as MCollective
+ * Agents, Actions and Agent Metadata that maps to the same terminology and behavior as MCollective
  * Auditing that is compatible with the Ruby based Choria auditing plugin
  * A framework for writing new Agents in Go that can be compiled into the Choria Server
  * Agents written in Go and compiled into the Choria Server:
@@ -13,6 +13,9 @@ Features:
    * `rpcutil` - General RPC utilities like extracting facts and statistics, compatible with MCollective as far as possible
    * `discovery` - Agent used to assist broadcast based discovery
  * A wrapper around the historical Ruby MCollective agent system that can run a MCollective agent in a sandbox without requiring the deprecated `mcollectived` daemon
+
+ Client Features:
+
  * A full featured Go client to the MCollective RPC system that is compatible with Ruby and Go nodes
    * Broadcast discovery
    * RPC Requests with the usual features like batches, direct, broadcast and more

--- a/mcorpc/client/client_test.go
+++ b/mcorpc/client/client_test.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/choria-io/go-protocol/protocol/v1"
 
+	"github.com/choria-io/go-choria/server/agents"
 	"github.com/choria-io/mcorpc-agent-provider/mcorpc"
 	"github.com/choria-io/mcorpc-agent-provider/mcorpc/ddl/agent"
-	"github.com/choria-io/go-choria/server/agents"
 
 	"github.com/choria-io/go-choria/choria"
 	client "github.com/choria-io/go-client/client"
@@ -178,7 +178,8 @@ var _ = Describe("McoRPC/Client", func() {
 			Expect(handled).To(Equal(2))
 			stats := result.Stats()
 			Expect(stats.RequestID).To(Equal(reqid))
-			Expect(stats.discoveredNodes).To(Equal([]string{"test.sender.0", "test.sender.1"}))
+			Expect(stats.discoveredNodes).To(Equal(strings.Fields("test.sender.0 test.sender.1")))
+			Expect(*stats.DiscoveredNodes()).To(Equal(strings.Fields("test.sender.0 test.sender.1")))
 			Expect(stats.unexpectedRespones.Hosts()).To(Equal([]string{}))
 			Expect(stats.OKCount()).To(Equal(2))
 			Expect(stats.All()).To(BeTrue())

--- a/mcorpc/client/stats.go
+++ b/mcorpc/client/stats.go
@@ -163,6 +163,11 @@ func (s *Stats) DiscoveredCount() int {
 	return len(s.discoveredNodes)
 }
 
+// DiscoveredNodes are the nodes that was discovered for this request
+func (s *Stats) DiscoveredNodes() *[]string {
+	return &s.discoveredNodes
+}
+
 // FailCount is the number of responses that were failures
 func (s *Stats) FailCount() int {
 	return int(s.failed.Load())


### PR DESCRIPTION
Previously in a early itteration of this client the options and discovery
would persiste between calls to Do() which while possibly handy was a bit
magical and made stats really weird - just like in the ruby client.

So we decided to ditch that but the client.Discover() remained and documented
that it will store targets and discovery time stats - while it would do none
of these things as the rest of the client have moved away from that model so
this was now just ill conceived.

We now ditch the whole client.Discover() idea and instead allow passing
a protocol.Filter into the Do() method and if that is done and no targets
are set then discovery will be done using that filter

Additionally the collective set using options will now be passed along
to the broadcast discovery system and stats handling is improved

Additionally DiscoveryTimeout can now be overriden

This is a breaking change but its for the best