### PR TITLE
(#126) ensure actions with no inputs pass validation 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/choria-io/mcorpc-agent-provider
 go 1.12
 
 require (
+	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
+	github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 // indirect
 	github.com/choria-io/go-choria v0.12.1-0.20190919154218-95d70c768260
 	github.com/choria-io/go-client v0.5.0
 	github.com/choria-io/go-config v0.0.4
@@ -18,4 +20,5 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/tidwall/gjson v1.3.5
 	go.uber.org/atomic v1.5.1
+	google.golang.org/appengine v1.6.1 // indirect
 )

--- a/mcorpc/ddl/agent/action.go
+++ b/mcorpc/ddl/agent/action.go
@@ -235,6 +235,9 @@ func (a *Action) ValidateRequestJSON(req json.RawMessage) (warnings []string, er
 func (a *Action) ValidateRequestData(data map[string]interface{}) (warnings []string, err error) {
 	validNames := a.InputNames()
 
+	// We currently ignore the process_results flag that may be set by the MCO RPC CLI
+	delete(data, "process_results")
+
 	for _, input := range validNames {
 		val, ok := data[input]
 
@@ -259,10 +262,6 @@ func (a *Action) ValidateRequestData(data map[string]interface{}) (warnings []st
 	}
 
 	for iname := range data {
-		if iname == "process_results" {
-			continue
-		}
-
 		matched := false
 		for _, vname := range validNames {
 			if vname == iname {


### PR DESCRIPTION
## Summary

This PR allows for actions without inputs to be defined and used by making sure that they pass validation.

This is done by improving the way the `process_results` flag is ignored - we now ignore it in all
cases by simply deleting it if it is present.

## In detail
This flag may be added automatically to a request and will not be
part of the DDL or JSON. We therefore need to ignore it.

Previously, we only ignored it when looking for extra inputs to a request, but we did not
ignore it for requests with no inputs.
This _should_ fix #126: In that issue, an external agent with no inputs
declared fails validation. 

NB: I have reorganized the tests very slightly to group similar tests under a single `Context` - let me know if that's an issue