### PR TITLE
(#155) Test multiple allow statements

### DIFF
--- a/mcorpc/client/stats.go
+++ b/mcorpc/client/stats.go
@@ -35,7 +35,7 @@ type Stats struct {
 	agent  string
 	action string
 
-	mu   *sync.Mutex
+	mu *sync.Mutex
 }
 
 // NewStats initializes a new stats instance

--- a/mcorpc/external/provider_test.go
+++ b/mcorpc/external/provider_test.go
@@ -66,7 +66,7 @@ var _ = Describe("McoRPC/External", func() {
 
 	Describe("Plugin", func() {
 		It("Should be a valid AgentProvider", func() {
-			p:= server.AgentProvider(prov)
+			p := server.AgentProvider(prov)
 			Expect(p).ToNot(BeNil())
 		})
 	})

--- a/mcorpc/testdata/policies/rego/multiple.rego
+++ b/mcorpc/testdata/policies/rego/multiple.rego
@@ -1,0 +1,13 @@
+package io.choria.mcorpc.authpolicy
+
+default allow = false
+
+allow {
+   input.agent = "ginkgo"
+   input.action = "boop"
+}
+
+allow {
+   input.agent = "other"
+   input.action = "poob"
+}


### PR DESCRIPTION
A rego file should have multiple tests for allowing an action, with
sets of evaluations exclusive to each other.